### PR TITLE
Update `read_nctiles` to be used with ECCOv4r4 data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
+.vscode
 .DS_Store
 /Manifest.toml
 docs/Manifest.toml

--- a/src/MITgcmTools.jl
+++ b/src/MITgcmTools.jl
@@ -29,7 +29,7 @@ export SeaWaterDensity, MixedLayerDepth
 """
     MITgcm_path
 
-Path to a MITgcm folder. `MITgcm_path[1]` should generally be used. `MITgcm_path[2]` is mostly 
+Path to a MITgcm folder. `MITgcm_path[1]` should generally be used. `MITgcm_path[2]` is mostly
 meant to facilitate comparisons between e.g. MITgcm releases when needed.
 """
 MITgcm_path = [ "" , ""]
@@ -66,8 +66,8 @@ module downloads
             mv(tmp_path,dir_out)
             rm(joinpath(MITgcmScratchSpaces.path,fil))
         end
-    end    
-    
+    end
+
 end
 
 MITgcm_download=downloads.MITgcm_download

--- a/src/ReadFiles.jl
+++ b/src/ReadFiles.jl
@@ -3,7 +3,7 @@
 """
     scan_rundir(pth::String)
 
-Scan a MITgcm run directory and standard output text file 
+Scan a MITgcm run directory and standard output text file
 ("output.txt" or "STDOUT.0000") and return a NamedTuple of
 collected information (various formats)
 
@@ -84,7 +84,7 @@ function scan_stdout(filout::String)
 
     #2 output files
 
-    #2.1 type (mdsio or mnc?) and overall size (ioSize) of output 
+    #2.1 type (mdsio or mnc?) and overall size (ioSize) of output
     tst_mdsio = !isempty(filter(x -> occursin("XC",x), readdir(pth)))
     pth_mnc=joinpath(pth,"mnc_test_0001")
     tst_mnc = isdir(pth_mnc)
@@ -169,7 +169,7 @@ function read_nctiles(fileName::String,fldName::String,mygrid::gcmgrid;
         f0=fill(NaN,mygrid.fSize[ff]...,s[3:end]...)
         n0=m0[1]
         for n in 1:nn
-            fileIn=@sprintf("%s.%04d.nc",fileRoot,n+n0)
+            @sprintf("%s.%04d.nc",fileRoot,n+n0)
             if isfile(fileIn) #skip if no file / blank tile
                 x = ClimateModels.ncread(fileIn,fldName,start,count)
                 i=collect(1:s[1]) .+ i0[n]
@@ -389,7 +389,7 @@ function read_namelist(fil)
     groups = meta[findall(occursin.('&',meta))]
 	groups = [Symbol(groups[1+2*(i-1)][3:end]) for i in 1:Int(length(groups)/2)]
 	params = fill(OrderedDict(),length(groups))
-		
+
 	for i in 1:length(groups)
 		ii=1+findall(occursin.(String(groups[i]),meta))[1]
 		i1=ii
@@ -417,9 +417,9 @@ function read_namelist(fil)
         for ii in keys(tmp0)
             tmp0[ii]=parse_param(tmp0[ii])
         end
-		params[i]=tmp0			
+		params[i]=tmp0
 	end
-		
+
     return MITgcm_namelist(Symbol.(groups),params)
 end
 
@@ -473,7 +473,7 @@ nml=read_namelist(fil)
 write_namelist(fil*"_new",namelist)
 ```
 
-or 
+or
 
 ```
 nml=read(fil,MITgcm_namelist())
@@ -484,9 +484,9 @@ function write_namelist(fil,namelist)
 	fid = open(fil, "w")
 	for jj in 1:length(namelist.groups)
         ii=namelist.groups[jj]
-		tmpA=namelist.params[jj] 
+		tmpA=namelist.params[jj]
 		params=(; zip(keys(tmpA),values(tmpA))...)
-			
+
         txt=fill("",length(params))
         for i in 1:length(params)
             x=params[i]
@@ -507,7 +507,7 @@ function write_namelist(fil,namelist)
             y[end]==',' ? y=y[1:end-1] : nothing
             txt[i]=y
         end
-			
+
 		txtparams=[" $(keys(params)[i]) = $(txt[i]),\n" for i in 1:length(params)]
 
 		write(fid," &$(ii)\n")
@@ -588,7 +588,7 @@ function read_mdsio(fil::String,rec::Integer)
 
     recl=prod(s)*L
     buff=Array{T}(undef, s...)
-        
+
     f=FortranFiles.FortranFile(fil,"r",access="direct",recl=recl,convert="big-endian")
     FortranFiles.read(f,rec=rec,buff)
     buff
@@ -613,7 +613,7 @@ end
     read_mdsio(pth::String,fil::String)
 
 Read a set of `MITgcm` MDSIO-type files (".data" binary + ".meta" text pair), combine, and return as an Array.
-Unlike `read_mdsio(fil::String)` where `fil` is one complete file name, this method will search within `pth` 
+Unlike `read_mdsio(fil::String)` where `fil` is one complete file name, this method will search within `pth`
 for files that start with `fil`.
 
 ```
@@ -634,7 +634,7 @@ function read_mdsio(pth::String,fil::String)
 
     m[1].nrecords>1 ? s=Tuple([m[1].dimList[:,1];m[1].nrecords]) : s=Tuple(m[1].dimList[:,1])
     x = Array{T,length(s)}(undef,s)
-    
+
     for k=1:length(m)
         ii=m[k].dimList[1,2]:m[k].dimList[1,3]
         jj=m[k].dimList[2,2]:m[k].dimList[2,3]
@@ -657,7 +657,7 @@ read_mdsio(xx::Array,x::MeshArray) = MeshArrays.read(xx::Array,x::MeshArray)
 """
     read_mnc(pth::String,fil::String,var::String)
 
-Read variable `var` from a set of `MITgcm` MNC-type files (netcdf files), combine, and 
+Read variable `var` from a set of `MITgcm` MNC-type files (netcdf files), combine, and
 return as an Array. This method will search within `pth` for files that start with `fil`.
 """
 function read_mnc(pth::String,fil::String,var::String)
@@ -712,7 +712,7 @@ end
 """
     GridLoad_mnc(γ::gcmgrid)
 
-Load grid variabes (XC, YC, Depth) model run directory (`joinpath(rundir,"mnc_test_0001")`).   
+Load grid variabes (XC, YC, Depth) model run directory (`joinpath(rundir,"mnc_test_0001")`).
 """
 function GridLoad_mnc(γ::gcmgrid)
     pth=joinpath(γ.path,"mnc_test_0001")
@@ -818,7 +818,7 @@ function GridLoad_mdsio(rundir::String)
         readcube(xx::Array,x::MeshArray) = read_mdsio(cube2compact(xx),x)
         readcube(fil::String,x::MeshArray) = read_mdsio(fil::String,x::MeshArray)
         writecube(x::MeshArray) = compact2cube(write(x))
-        writecube(fil::String,x::MeshArray) = write(fil::String,x::MeshArray)    
+        writecube(fil::String,x::MeshArray) = write(fil::String,x::MeshArray)
         γ=gcmgrid(rundir,"CubeSphere",6,fill((32,32),6),[32 32*6],elty, readcube, writecube)
     else
         s1=exps_ioSize
@@ -831,7 +831,7 @@ end
 """
     read_available_diagnostics(fldname::String; filename="available_diagnostics.log")
 
-Get the information for a particular variable `fldname` from the 
+Get the information for a particular variable `fldname` from the
 `available_diagnostics.log` text file generated by `MITgcm`.
 """
 function read_available_diagnostics(fldname::String; filename="available_diagnostics.log")

--- a/src/ReadFiles.jl
+++ b/src/ReadFiles.jl
@@ -116,9 +116,9 @@ Read model output from NCTiles file and convert to MeshArray instance.
 ```
 mygrid=GridSpec("LatLonCap")
 fileName="nctiles_grid/GRID"
-Depth=read_nctiles(fileName,"Depth",mygrid)
-hFacC=read_nctiles(fileName,"hFacC",mygrid)
-hFacC=read_nctiles(fileName,"hFacC",mygrid,I=(:,:,1))
+Depth=read_nctiles(2,fileName,"Depth",mygrid)
+hFacC=read_nctiles(2,fileName,"hFacC",mygrid)
+hFacC=read_nctiles(2,fileName,"hFacC",mygrid,I=(:,:,1))
 ```
 """
 function read_nctiles(eccoVersion4Release::Int64,fileName::String,fldName::String,mygrid::gcmgrid;

--- a/src/ReadFiles.jl
+++ b/src/ReadFiles.jl
@@ -190,7 +190,7 @@ function read_nctiles(eccoVersion4Release::Int64,fileName::String,fldName::Strin
     elseif eccoVersion4Release == 4
         fill!(f, NaN)
         tiles=Tiles(mygrid,90,90)
-        year=pth0[end-3:end]
+        year=pth0[findlast('/', pth0)+1:end]
         months=vcat("0" .* string.(1:9), string.(10:12))
         fileCounter = 0 # for indexing the time in the MeshArray
         for month in months


### PR DESCRIPTION
This PR adds the keyword argument `eccoVersion4Relase4` to `read_nctiles` so that users can specify if they are using ECCO v4r4 which had a file naming convention changed ([see below](https://github.com/gaelforget/MITgcmTools.jl/pull/69#issuecomment-1516310952)). By default `eccoVersion4Relase4=false`.

There are still some things that need to be ironed out for the release 4 parts of `read_nctiles`:

- currently the number of depth levels is set to be 50 in the function (`nr=50`) but would be better if this came from the input data
- a blank `MeshArray` is initialised, which is the `fill!`ed with `NaN` but after the data is copied to this `MeshArray` the `NaN`s have changed to zero
- it is only setup to work for monthly data that is stored in a directory that is the name of the year it is from, i.e.

```
localpathtodata/1992/UVELMASS_1992_01.nc
```

If the whole `1992` folder for ECCOv4r4 is downloaded from ECCO drive `read_nctiles` will work (as long as nothing is renamed.)
- how can the data from multiple years be concatenated into a single `MeshArray`? Or is having multiple `MeshArray`s, each corresponding to a year of monthly data, sufficient?
- likely there are optimisations that could be made to how the code runs.

## Example

After downloading `UVELMASS_1992_01.nc` and `UVELMASS_1992_07.nc` from ECCO drive and saving into a local directory called `1992` the following example runs on my machine and produces plots of the five faces that look to match the [LLC90 grid example](https://juliaclimate.github.io/MeshArrays.jl/dev/tutorials/basics.html) .

```julia
julia> mygrid =GridSpec("LatLonCap",MeshArrays.GRID_LLC90)
julia> test_file = joinpath(@__DIR__, "pathtodirectory/1992/UVELMASS_1992_01.nc")
julia> test_read_nc = read_nctiles(test_file, "UVELMASS", mygrid, eccoVersion4Release4=true)
[ Info: Reading file .../1992/UVELMASS_1992_01.nc
[ Info: Reading file .../1992/UVELMASS_1992_07.nc
5×50×2 MeshArrays.gcmarray{Float64, 3, Matrix{Float64}}:
[:, :, 1] =
 [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]  …  [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]
 [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]     [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]
 [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]     [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]
 [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]     [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]
 [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]     [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]

[:, :, 2] =
 [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]  …  [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]
 [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]     [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]
 [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]     [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]
 [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]     [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]
 [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]     [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]
```

which returns a `MeshArray` made up of the two files (can see there are zeros instead of `NaN`s).

Plotting the five faces (at sea surface level)  for `UVELMASS_1992_01.nc`
![eccov4r4_face_plots_01](https://user-images.githubusercontent.com/75812103/234258812-35c459f2-b1a0-4b5c-951f-01c0ece941d4.png)

and for `UVELMASS_1992_07.nc`
![eccov4r4_face_plots_07](https://user-images.githubusercontent.com/75812103/234259093-5cab1cd4-527b-402c-9795-52444d8351d0.png)

These were plotted using CairoMakie, e.g., 

```julia
fig = Figure(size = (1000, 1000))
ax = [Axis(fig[j, i]) for i in 1:3, j in 1:2]
titles = "Face " .* string.(1:5)
for i in 1:5
    heatmap!(ax[i], map(x-> x == 0 ? NaN : x, test_read_nc[i, 1, 1]))
    ax[i].title = titles[i]
end
fig
```


Closes #68.